### PR TITLE
Use multi-stage build for gleam

### DIFF
--- a/gleam/0.4/otp-22-alpine/Dockerfile
+++ b/gleam/0.4/otp-22-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # built with ./build.sh, do not edit manually
-FROM wojtekmach/erlang:22-alpine
+FROM wojtekmach/erlang:22-alpine AS builder
 
 ENV GLEAM_VERSION="0.4.0" \
   GLEAM_SHA256="00af1865422ef8c57bab7b7f234b03b27cacd69f6eb23375615c60cb089458e0" \
@@ -24,8 +24,12 @@ RUN set -xe \
   && cd /usr/local/src/gleam \
   && make build \
   && make install
+
+FROM wojtekmach/erlang:22-alpine
+
 RUN set -xe \
-  # && apk del .build-deps \
-  && cp /root/.cargo/bin/gleam /usr/local/bin
+  && apk add -vv --no-cache so:libgcc_s.so.1
+
+COPY --from=builder /root/.cargo/bin/gleam /usr/local/bin
 
 CMD ["gleam"]

--- a/templates/gleam.dockerfile
+++ b/templates/gleam.dockerfile
@@ -1,5 +1,5 @@
 # built with ./build.sh, do not edit manually
-FROM wojtekmach/erlang:%OTP_VERSION%-alpine
+FROM wojtekmach/erlang:%OTP_VERSION%-alpine AS builder
 
 ENV GLEAM_VERSION="%GLEAM_VERSION%" \
   GLEAM_SHA256="%GLEAM_SHA256%" \
@@ -24,8 +24,12 @@ RUN set -xe \
   && cd /usr/local/src/gleam \
   && make build \
   && make install
+
+FROM wojtekmach/erlang:%OTP_VERSION%-alpine
+
 RUN set -xe \
-  # && apk del .build-deps \
-  && cp /root/.cargo/bin/gleam /usr/local/bin
+  && apk add -vv --no-cache so:libgcc_s.so.1
+
+COPY --from=builder /root/.cargo/bin/gleam /usr/local/bin
 
 CMD ["gleam"]


### PR DESCRIPTION
Hey, saw your repo (issue #1) and wanted to try a multi stage docker build to shrink the gleam image.

Ran `./build.sh` to generate the docker image:
```
docker image ls | grep gleam
wojtekmach/gleam                                                      0.4-otp-22-alpine   a8fa8dd5ffb2        23 minutes ago       884MB
```

After the change:
```
docker image ls | grep gleam
wojtekmach/gleam                                                      0.4-otp-22-alpine   b86d97669059        3 minutes ago       79.2MB
```

After building the image I ran into one issue where it was reporting an error:
```
docker run --rm --tty wojtekmach/gleam:0.4-otp-22-alpine
Error loading shared library libgcc_s.so.1: No such file or directory (needed by /usr/local/bin/gleam)
Error relocating /usr/local/bin/gleam: _Unwind_Resume: symbol not found
Error relocating /usr/local/bin/gleam: _Unwind_GetRegionStart: symbol not found
Error relocating /usr/local/bin/gleam: _Unwind_SetGR: symbol not found
Error relocating /usr/local/bin/gleam: _Unwind_GetDataRelBase: symbol not found
Error relocating /usr/local/bin/gleam: _Unwind_DeleteException: symbol not found
Error relocating /usr/local/bin/gleam: _Unwind_GetLanguageSpecificData: symbol not found
Error relocating /usr/local/bin/gleam: _Unwind_RaiseException: symbol not found
Error relocating /usr/local/bin/gleam: _Unwind_FindEnclosingFunction: symbol not found
Error relocating /usr/local/bin/gleam: _Unwind_Backtrace: symbol not found
Error relocating /usr/local/bin/gleam: _Unwind_GetIPInfo: symbol not found
Error relocating /usr/local/bin/gleam: _Unwind_GetTextRelBase: symbol not found
Error relocating /usr/local/bin/gleam: _Unwind_SetIP: symbol not found
```

I had to install libgcc and running the container worked after that.
```
RUN set -xe \
  && apk add -vv --no-cache so:libgcc_s.so.1
```